### PR TITLE
Pin ty version in CI lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Static typing with ty
         run: |
-          uvx ty check . --ignore unresolved-import
+          ty check . --ignore unresolved-import


### PR DESCRIPTION
Avoids random CI failures by pinning ty version to the one specified in requirements_dev.txt (0.0.18) instead of pulling the latest unpinned tool via uvx.